### PR TITLE
Feature/custom webpack

### DIFF
--- a/src/config/configure-webpack.js
+++ b/src/config/configure-webpack.js
@@ -27,7 +27,7 @@ export default function (config) {
     customWebpackDev.resolve = {
       root: [
         path.resolve(config.basePath, 'node_modules'),
-        path.resolve(config.basePath, 'src/lib'),
+        path.resolve(config.basePath, 'src/lib')
       ]
     };
     customWebpackProd.resolve = {
@@ -36,7 +36,7 @@ export default function (config) {
         path.resolve(config.basePath, 'src/lib')
       ]
     };
-  } catch (e) { console.log('Loading webpack defaults...') }
+  } catch (e) { console.log(e) }
 
   // jquery configuration
   try {
@@ -47,7 +47,7 @@ export default function (config) {
       delete customWebpackDev.jquery;
       delete customWebpackProd.jquery;
     }
-  } catch (e) {}
+  } catch (e) { console.log(e) }
 
   // plugins (bower-webpack-plugin)
   try {
@@ -67,7 +67,7 @@ export default function (config) {
       delete customWebpackDev.bower;
       delete customWebpackProd.bower;
     }
-  } catch (e) {}
+  } catch (e) { console.log(e) }
   
   // delete any original webpack objects
   delete config.webpack;

--- a/src/config/configure-webpack.js
+++ b/src/config/configure-webpack.js
@@ -1,0 +1,91 @@
+require("babel-register", {
+  presets: [ 'es2015' ]
+});
+
+import path from 'path';
+import fs from 'fs';
+import defaultWebpackDev from './webpack.config';
+import defaultWebpackProd from './webpack.prod.config';
+import BowerWebpackPlugin from 'bower-webpack-plugin';
+import deepAssign from 'deep-assign';
+
+export default function (config) {
+  
+  var bundle = {
+    entry: path.resolve(config.basePath, './src/assets/js/index.js'),
+    output: {
+      path: path.resolve(config.basePath, './dist/assets/js')
+    }
+  };
+  var customWebpackDev = {};
+  var customWebpackProd = {};
+
+  try {
+    // attempt to load custom config
+    customWebpackDev = require(path.resolve(config.basePath, config.webpack.dev)).default;
+    customWebpackProd = require(path.resolve(config.basePath, config.webpack.prod)).default;
+    customWebpackDev.resolve = {
+      root: [
+        path.resolve(config.basePath, 'node_modules'),
+        path.resolve(config.basePath, 'src/lib'),
+      ]
+    };
+    customWebpackProd.resolve = {
+      root: [
+        path.resolve(config.basePath, 'node_modules'),
+        path.resolve(config.basePath, 'src/lib')
+      ]
+    };
+  } catch (e) { console.log('Loading webpack defaults...') }
+
+  // jquery configuration
+  try {
+    if (customWebpackDev.jquery && customWebpackProd.jquery) {
+      defaultWebpackDev.externals = defaultWebpackProd.externals = {
+        'jquery': 'jQuery'
+      }
+      delete customWebpackDev.jquery;
+      delete customWebpackProd.jquery;
+    }
+  } catch (e) {}
+
+  // plugins (bower-webpack-plugin)
+  try {
+    if (customWebpackDev.bower && customWebpackProd.bower) {
+      if (!defaultWebpackDev.plugins || !defaultWebpackDev.plugins.length) {
+        defaultWebpackDev.plugins = [];
+      }
+      if (!defaultWebpackProd.plugins || !defaultWebpackProd.plugins.length) {
+        defaultWebpackProd.plugins = [];
+      }
+      var bowerConfig = new BowerWebpackPlugin({
+        modulesDirectories: ['src/lib'],
+        manifestFiles: 'bower.json'
+      });
+      defaultWebpackDev.plugins.push(bowerConfig);
+      defaultWebpackProd.plugins.push(bowerConfig);
+      delete customWebpackDev.bower;
+      delete customWebpackProd.bower;
+    }
+  } catch (e) {}
+  
+  // delete any original webpack objects
+  delete config.webpack;
+  
+  // return webpack configuration
+  return {
+    dev: deepAssign(
+      {}, 
+      defaultWebpackDev,
+      bundle,
+      customWebpackDev
+    ),
+    prod: deepAssign(
+      {}, 
+      defaultWebpackProd,
+      bundle,
+      customWebpackProd
+    )
+  };
+  
+}

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -6,7 +6,6 @@ import configureWebpack        from './configure-webpack';
 export default function createDefaults(config) {
 
   var webpack = configureWebpack(config);
-  console.log(webpack);
 
   var DEFAULTS = {
   

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,19 +1,14 @@
-import path             from 'path';
-import deepAssign       from 'deep-assign';
-import customTags       from './custom-tags';
-import webpackDev       from './webpack.config';
-import webpackProd      from './webpack.prod.config';
+import path                    from 'path';
+import deepAssign              from 'deep-assign';
+import customTags              from './custom-tags';
+import configureWebpack        from './configure-webpack';
 
 export default function createDefaults(config) {
-  
-  const webpackRelative = {
-    entry: path.resolve(config.basePath, './src/assets/js/index.js'),
-    output: {
-      path: path.resolve(config.basePath, './dist/assets/js')
-    }
-  };
 
-  return {
+  var webpack = configureWebpack(config);
+  console.log(webpack);
+
+  var DEFAULTS = {
   
     metadata: {
       title: 'Metalpress',
@@ -23,8 +18,6 @@ export default function createDefaults(config) {
     },
     
     filedata: false,
-    
-    prompt: false,
     
     sitemap: false,
     
@@ -120,11 +113,10 @@ export default function createDefaults(config) {
     preMiddleware: false,
     postMiddleware: false,
     
-    webpack: {
-      dev: deepAssign({}, webpackDev, webpackRelative),
-      prod: deepAssign({}, webpackProd, webpackRelative)
-    }
+    webpack
 
   };
+
+  return deepAssign({}, DEFAULTS, config);
 
 }

--- a/src/config/webpack.config.js
+++ b/src/config/webpack.config.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import BowerWebpackPlugin from 'bower-webpack-plugin';
 
 export default {
   entry: path.resolve(__dirname, './src/assets/js/index.js'),
@@ -27,14 +26,5 @@ export default {
   },
   resolveLoader: {
     root: path.join(__dirname, '../../node_modules')
-  },
-  externals: {
-    'jquery': 'jQuery'
-  },
-  plugins: [
-    new BowerWebpackPlugin({
-      modulesDirectories: ['src/lib'],
-      manifestFiles: 'bower.json'
-    })
-  ]
+  }
 }

--- a/src/config/webpack.prod.config.js
+++ b/src/config/webpack.prod.config.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import webpack from 'webpack';
-import BowerWebpackPlugin from 'bower-webpack-plugin';
 
 export default {
   entry: path.resolve(__dirname, './src/assets/js/index.js'),
@@ -26,14 +25,7 @@ export default {
   resolveLoader: {
     root: path.join(__dirname, '../../node_modules')
   },
-  externals: {
-    'jquery': 'jQuery'
-  },
   plugins: [
-    new BowerWebpackPlugin({
-      modulesDirectories: ['src/lib'],
-      manifestFiles: 'bower.json'
-    }),
     new webpack.optimize.UglifyJsPlugin({
       minimize: true,
       compress: {

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,7 @@ import date             from 'metalsmith-build-date';
 import robots           from 'metalsmith-robots';
 import shortcodes       from 'metalsmith-flexible-shortcodes';
 import diff             from 'metalsmith-differential';
-import {
-  loadJsOrYaml
-} from './util/fs';
+import { loadJsOrYaml } from './util/fs';
 // prod
 import htmlMinifier     from 'metalsmith-html-minifier';
 import fingerprint      from 'metalsmith-fingerprint';
@@ -41,8 +39,8 @@ import createDefaults   from './config/defaults';
 
 export default function (config = {}, callback) {
 
-  let DEFAULT_OPTIONS = createDefaults(config);
-  
+  let options = createDefaults(config);
+
   try {
     for (var collection in config.pagination) {
       // check every pagination collection and load metadata into the original key
@@ -53,8 +51,6 @@ export default function (config = {}, callback) {
       config.pagination[collection].pageMetadata = loadJsOrYaml(metadata);
     }
   } catch(e) { console.log('could not resolve pagination metadata', e) }
-
-  const options = deepAssign({}, DEFAULT_OPTIONS, config);
 
   // Config
   // --------------------------------------------------------------------------


### PR DESCRIPTION
- adds custom support for webpack files
- passing `bower: true` will enable `bower-webpack-plugin` (defaults to `false`)
- passing `jquery: true` will enable externals to load `jquery` from the global `jQuery` (defaults to `false`)
- when using custom config files both `webpack.config.js` and `webpack.prod.config.js` must be specified
- webpack uses loaders form metalpress internally. If you need to add new loaders, you must override `resolveLoader` within your config. Ex. `resolveLoader: { root: path.resolve(__dirname, 'node_modules') }`
- when using custom webpack files, the resolved modules change from metalpress to the following: *this specifies new default directories to look for modules. You can override if needed*
```
resolve = { 
  root: [
        path.resolve(config.basePath, 'node_modules'),
        path.resolve(config.basePath, 'src/lib') 
  ]
}
```

To simply change the bundle entries, use the following minimal config:

```js
import path from 'path'

export default {
  entry: path.resolve(__dirname, './src/assets/js/index.js'),
  output: {
    path: path.resolve(__dirname, './dist/assets/js'),
    filename: 'bundle.js'
  }
};
```